### PR TITLE
Npm build fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,5 +30,10 @@
     "react/jsx-filename-extension": ["off", { "extensions": [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": "off",
     "no-nested-ternary": "off"
+  },
+  "settings": {
+    "import/extensions": [
+      ".css"
+    ]
   }
 }


### PR DESCRIPTION
Required to successfully execute `npm run build`.
Produces following error if note present:
```
[eslint]
src/index.js
  Line 8:8:   Unable to resolve path to module '@fontsource/oswald/200.css'  import/no-unresolved
  Line 9:8:   Unable to resolve path to module '@fontsource/oswald/300.css'  import/no-unresolved
  Line 10:8:  Unable to resolve path to module '@fontsource/oswald/400.css'  import/no-unresolved
  Line 11:8:  Unable to resolve path to module '@fontsource/oswald/500.css'  import/no-unresolved
  Line 12:8:  Unable to resolve path to module '@fontsource/oswald/600.css'  import/no-unresolved
  Line 13:8:  Unable to resolve path to module '@fontsource/oswald/700.css'  import/no-unresolved
```