### PR TITLE
CI/CD Pipeline for automatic Deployment of development and main

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,78 @@
+name: NodeJS with Webpack
+
+on:
+  push:
+    branches: 
+      - development
+      - main
+  pull_request:
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+          cache: 'npm'
+      - name: Dev dependencies
+        run: npm install --save-dev
+      - name: Check eslint
+        run: npm run lint
+      - name: Check prettier
+        run: npm run prettier-check
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: latest
+        cache: 'npm'
+    - name: Install Modules
+      run: npm install
+    - name: Build
+      run: npm run build
+    - uses: actions/upload-artifact@master
+      with:
+        name: build_dir
+        path: dist
+    - name: List files
+      run: ls -la
+    - name: List files build
+      run: ls -la dist
+
+  deployment:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: build_dir
+          path: dist
+      - name: List files
+        run: ls -la
+      - name: List files build
+        run: ls -la dist
+      - name: Setup SSH
+        env:
+          PRIV_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir ~/.ssh
+          echo "$PRIV_KEY" >> ~/.ssh/key
+          echo "$KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/key
+      - name: Deploy Development
+        run: scp -i ~/.ssh/key -r dist/* ${{ secrets.SSH_USER }}@${{ secrets.REMOTE_HOST }}:${{ secrets.DEPLOY_DIR_DEV }}
+      - name: Deploy Production
+        if: github.head_ref == 'main'
+        run: scp -i ~/.ssh/key -r dist/* ${{ secrets.SSH_USER }}@${{ secrets.REMOTE_HOST }}:${{ secrets.DEPLOY_DIR_PROD }}

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "scripts": {
     "start": "vite",
     "build": "vite build",
-    "lint": "eslint .",
-    "prettier": "prettier . --write",
-    "prettier-check": "prettier . --check",
+    "lint": "eslint src",
+    "prettier": "prettier src --write",
+    "prettier-check": "prettier src --check",
     "serve": "vite preview",
     "dev": "vite build --outDir build",
     "deploy": "vite build --outDir live"


### PR DESCRIPTION
Nobody needs me for deployment. Therefore I raise you these workflows.

The boring part:
For every opened PR, check if we can build and whether the linter(s) complains about something.
Slightly modified `package.json` for this to speed up linting. Please advise whether this should use a dedicated npm script, or if this is fine.

The fun part:
Every merge to `deployment` and `main` automatically get built and pushed to web.
Currently `deployment` is hosted on https://ci-dev.kacky.gg, while main is served under https://ci.kacky.gg
This will need a minor modification in branch permissions, removing the ability to push to `development` directly and requiring merges - but since I am the only one with permissions for this right now, this should not be an issue.

We will have 3k CI minutes monthly with Github Actions, a build takes about 30s (caching goes brrrrrrrr), pushing built website to web should be another 30s max, therefore it should be plenty.

If this gets accepted, I propose we have a short testing phase and after that, if no issues arise, drop the testing subdomains and move it to the "real" domains (dev.kacky.gg and kacky.gg).
Having the built code of PRs themselves available somewhere would be cool, but I think that should be done with already available Netlify or Vercel workflows, since it's a bit more complex.
Issue #61 is a feature that would be a next step in the DevOps roadmap.